### PR TITLE
Make listening data page compatible with new data acquisition

### DIFF
--- a/frontend/src/routes/(app)/listening/+page.server.ts
+++ b/frontend/src/routes/(app)/listening/+page.server.ts
@@ -8,31 +8,9 @@ export const load: PageServerLoad = async ({locals: { supabase, session } }) => 
             }
         }
         const { data, error } = await supabase.functions.invoke("get-user-data", headers)
+        if (error) console.log(error)
 
-        if (error) {
-            console.log(error)
-        }
-
-        const song_data: any[] = JSON.parse(data)
-        let songs: {
-            album_art_path: string
-            title: string
-            artists: string[]
-            album: string
-        }[] | null = []
-
-        if (song_data) {
-            for (const song of song_data) {
-                songs.push({
-                    album_art_path: song.track_album.image,
-                    title: song.track_name,
-                    artists: song.track_artists,
-                    album: song.track_album.album_name
-                })
-            }
-        } else {
-            songs = null;
-        }
+        const songs = JSON.parse(data)
         return { songs }
     } else {
         throw Error("User does not have session.") 


### PR DESCRIPTION
Did a couple of things with this one
- Made get-user-data query the correct schema/tables in compliance w/ new data acquisition & improved comments
- Modified frontend to expect data in the correct format without any of its own parsing so that future refactors to get-user-data will work without extra tweaks
- Refactored edge functions to remove extra logs and the deprecated Deno `serve` function (uses `Deno.serve` instead, which doesn't require any imports)

Fixes #31 